### PR TITLE
Update MIT license year and author

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Venly.io
+Copyright (c) 2025 Tim Dierckxsens
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- update LICENSE to reflect the MIT License for 2025

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68527f994fbc832f84d36514df09842f