### PR TITLE
Add runtime config via .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Environment variables for Venly Demo
+# Copy this file to .env and provide your values
+ARKETYPE_CLIENT_SECRET=replace-me

--- a/README.md
+++ b/README.md
@@ -21,3 +21,19 @@ This demo shows how to integrate [Venly's Wallet SDK](https://docs.venly.io) in 
 ```html
 <script src="https://unpkg.com/@venly/sdk-wallets"></script>
 ```
+
+## 🌱 Environment configuration
+
+Create a `.env` file in the project root before starting the demo. The file is used to generate a runtime configuration script that is loaded by the application.
+
+```
+cp .env.example .env
+```
+
+Edit `.env` and provide your Venly values:
+
+```
+ARKETYPE_CLIENT_SECRET=your-secret
+```
+
+Running `npm start` will automatically generate `assets/js/runtime-config.js` from your `.env` file.

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -28,7 +28,7 @@
         env: app.env,
         connect: app.env + (app.useLocalConnect ? '-local' : '') + (app.useLocalKeycloak ? '-local' : ''),
         api: useLocalApi ? 'http://localhost:8581/api' : 'https://api-wallet' + resolvedEnv + '.venly.io/api',
-        arketypeClientSecret: '02053a9d-8293-43c4-a201-f8669f1329af', // Only visible for demo purpose, this secret should be configured in application backend
+        arketypeClientSecret: window._env_ && window._env_.ARKETYPE_CLIENT_SECRET ? window._env_.ARKETYPE_CLIENT_SECRET : '' // Only visible for demo purpose, this secret should be configured in application backend
     };
 
     function resolveEnv(appEnv) {

--- a/generate-env.js
+++ b/generate-env.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+const dotenv = require('dotenv');
+
+// Load environment variables from .env if present
+dotenv.config();
+
+const envVars = {
+  ARKETYPE_CLIENT_SECRET: process.env.ARKETYPE_CLIENT_SECRET || ''
+};
+
+const targetPath = path.join(__dirname, 'assets/js/runtime-config.js');
+const content = `window._env_ = ${JSON.stringify(envVars, null, 2)};\n`;
+
+fs.writeFileSync(targetPath, content);
+

--- a/index.html
+++ b/index.html
@@ -755,6 +755,7 @@
 <script src="/node_modules/jquery/dist/jquery.min.js"></script>
 <script src="/assets/js/vendor/modernizr-custom.js"></script>
 <script src="/node_modules/bootstrap/dist/js/bootstrap.bundle.js"></script>
+<script src="/assets/js/runtime-config.js"></script>
 <script src="/assets/js/settings.js?v=0.0.5"></script>
 <script src="/assets/js/auth.js?v=0.0.5"></script>
 <script src="/assets/js/form-and-events.js?v=0.0.5"></script>

--- a/package.json
+++ b/package.json
@@ -13,11 +13,13 @@
     "js-sha256": "^0.11.0",
     "jsencrypt": "3.3.2",
     "popper.js": "^1.15.0",
-    "web3": "1.8.0"
+    "web3": "1.8.0",
+    "dotenv": "^16.0.3"
   },
   "scripts": {
-    "start": "http-server -p 4000 -a 127.0.0.1 -c-1",
-    "start-ext": "http-server -p 4000 -c-1"
+    "start": "node generate-env.js && http-server -p 4000 -a 127.0.0.1 -c-1",
+    "start-ext": "node generate-env.js && http-server -p 4000 -c-1",
+    "generate-env": "node generate-env.js"
   },
   "devDependencies": {
     "http-server": "^14.1.1"

--- a/pages/ethers.html
+++ b/pages/ethers.html
@@ -299,6 +299,7 @@
 <script src="/node_modules/jquery/dist/jquery.min.js"></script>
 <script src="/assets/js/vendor/modernizr-custom.js"></script>
 <script src="/node_modules/bootstrap/dist/js/bootstrap.bundle.js"></script>
+<script src="/assets/js/runtime-config.js"></script>
 <script src="/node_modules/web3/dist/web3.min.js"></script>
 <script src="/node_modules/ethers/dist/ethers.umd.min.js"></script>
 <script src="/assets/js/plugins.js"></script>

--- a/pages/nonfungibles.html
+++ b/pages/nonfungibles.html
@@ -286,6 +286,7 @@
 <script src="/node_modules/jquery/dist/jquery.min.js"></script>
 <script src="/assets/js/vendor/modernizr-custom.js"></script>
 <script src="/node_modules/bootstrap/dist/js/bootstrap.bundle.js"></script>
+<script src="/assets/js/runtime-config.js"></script>
 <script src="/assets/js/settings.js"></script>
 <script src="/assets/js/plugins.js"></script>
 <script src="/assets/js/form-and-events.js"></script>

--- a/pages/public-key-encryption.html
+++ b/pages/public-key-encryption.html
@@ -221,6 +221,7 @@
 <script src="/node_modules/jquery/dist/jquery.min.js"></script>
 <script src="/assets/js/vendor/modernizr-custom.js"></script>
 <script src="/node_modules/bootstrap/dist/js/bootstrap.bundle.js"></script>
+<script src="/assets/js/runtime-config.js"></script>
 <script src="/assets/js/settings.js"></script>
 <script src="/assets/js/plugins.js"></script>
 <script src="/assets/js/form-and-events.js"></script>

--- a/pages/simple-get-wallets.html
+++ b/pages/simple-get-wallets.html
@@ -112,6 +112,7 @@
 <script src="/node_modules/jquery/dist/jquery.min.js"></script>
 <script src="/assets/js/vendor/modernizr-custom.js"></script>
 <script src="/node_modules/bootstrap/dist/js/bootstrap.bundle.js"></script>
+<script src="/assets/js/runtime-config.js"></script>
 <script src="/assets/js/settings.js"></script>
 <script src="/assets/js/plugins.js"></script>
 <script src="/assets/js/main.js"></script>

--- a/pages/test-api.html
+++ b/pages/test-api.html
@@ -238,6 +238,7 @@
 <script src="/node_modules/jquery/dist/jquery.min.js"></script>
 <script src="/assets/js/vendor/modernizr-custom.js"></script>
 <script src="/node_modules/bootstrap/dist/js/bootstrap.bundle.js"></script>
+<script src="/assets/js/runtime-config.js"></script>
 <script src="/assets/js/settings.js"></script>
 <script src="/assets/js/plugins.js"></script>
 <script src="/assets/js/form-and-events.js"></script>

--- a/pages/verification.html
+++ b/pages/verification.html
@@ -193,6 +193,7 @@
 <script src="/node_modules/jquery/dist/jquery.min.js"></script>
 <script src="/assets/js/vendor/modernizr-custom.js"></script>
 <script src="/node_modules/bootstrap/dist/js/bootstrap.bundle.js"></script>
+<script src="/assets/js/runtime-config.js"></script>
 <script src="/assets/js/settings.js?v=0.0.5"></script>
 <script src="/assets/js/auth.js?v=0.0.5"></script>
 <script src="/assets/js/form-and-events.js?v=0.0.5"></script>

--- a/pages/web3-provider-skip-auth.html
+++ b/pages/web3-provider-skip-auth.html
@@ -295,6 +295,7 @@
 <script src="/node_modules/jquery/dist/jquery.min.js"></script>
 <script src="/assets/js/vendor/modernizr-custom.js"></script>
 <script src="/node_modules/bootstrap/dist/js/bootstrap.bundle.js"></script>
+<script src="/assets/js/runtime-config.js"></script>
 <script src="/node_modules/web3/dist/web3.min.js"></script>
 <script src="/assets/js/plugins.js"></script>
 <script src="/assets/js/settings.js"></script>

--- a/pages/web3-provider.html
+++ b/pages/web3-provider.html
@@ -295,6 +295,7 @@
 <script src="/node_modules/jquery/dist/jquery.min.js"></script>
 <script src="/assets/js/vendor/modernizr-custom.js"></script>
 <script src="/node_modules/bootstrap/dist/js/bootstrap.bundle.js"></script>
+<script src="/assets/js/runtime-config.js"></script>
 <script src="/node_modules/web3/dist/web3.min.js"></script>
 <script src="/assets/js/plugins.js"></script>
 <script src="/assets/js/settings.js"></script>

--- a/pages/web3modal.html
+++ b/pages/web3modal.html
@@ -157,6 +157,7 @@
 <script src="/node_modules/jquery/dist/jquery.min.js"></script>
 <script src="/assets/js/vendor/modernizr-custom.js"></script>
 <script src="/node_modules/bootstrap/dist/js/bootstrap.bundle.js"></script>
+<script src="/assets/js/runtime-config.js"></script>
 <script src="/node_modules/web3/dist/web3.min.js"></script>
 <script src="/node_modules/@venly/web3modal/dist/index.js"></script>
 <script src="/node_modules/@venly/web3-provider/dist/web3-provider.js"></script>


### PR DESCRIPTION
## Summary
- load sensitive config from `runtime-config.js`
- create a helper script `generate-env.js` and hook it into npm scripts
- document environment variables and usage

## Testing
- `npm run generate-env` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_685283081eac832fb07d763a0973c100