### PR TITLE
Fix duplicated script in auth pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -759,7 +759,6 @@
 <script src="/assets/js/auth.js?v=0.0.5"></script>
 <script src="/assets/js/form-and-events.js?v=0.0.5"></script>
 <script src="/assets/js/main.js?v=0.0.5"></script>
-<script src="/assets/js/auth.js?v=0.0.5"></script>
 <script src="/assets/js/arketype-wallets.js?v=0.0.5"></script>
 
 </body>

--- a/pages/verification.html
+++ b/pages/verification.html
@@ -197,7 +197,6 @@
 <script src="/assets/js/auth.js?v=0.0.5"></script>
 <script src="/assets/js/form-and-events.js?v=0.0.5"></script>
 <script src="/assets/js/main.js?v=0.0.5"></script>
-<script src="/assets/js/auth.js?v=0.0.5"></script>
 <script src="/assets/js/arketype-verification.js?v=0.0.5"></script>
 
 </body>


### PR DESCRIPTION
## Summary
- avoid loading `auth.js` twice on the homepage
- fix duplicate script tag in the verification page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68527c1295a0832fa3556f17a0d76759