### PR TITLE
Fix token handling in updateToken

### DIFF
--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -77,8 +77,9 @@
     };
 
     app.updateToken = (token) => {
-        $('input[name="bearer"]').val(app.auth.token);
-        $('#auth-token').val(token);
+        const t = token || '';
+        $('input[name="bearer"]').val(t);
+        $('#auth-token').val(t);
     };
 
 })();


### PR DESCRIPTION
## Summary
- update both token fields directly from the `token` parameter
- avoid references to `app.auth` so logout doesn't throw

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68528852a2f8832fb8cd75a3d2ab8768